### PR TITLE
fix for #2598: DITAVAL passthrough does not preserve attributes in HTML5 TOC. 

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -105,7 +105,6 @@ See the accompanying LICENSE file for applicable license.
         <isset property="out.ext"/>
       </not>
     </condition>
-    <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>
     <!-- Set to "true" if you get out-of-memory errors during preprocess
     while processing very large (thousands of files) document sets. -->
     <condition property="dita.html5.reloadstylesheet" value="false">
@@ -179,6 +178,7 @@ See the accompanying LICENSE file for applicable license.
   <macrodef name="html5.topics">
     <element name="params" optional="true" implicit="true"/>
     <sequential>
+      <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>
       <pipeline message="Convert DITA topic to HTML5" taskname="xslt">
       <xslt basedir="${dita.temp.dir}"
             destdir="${output.dir}"


### PR DESCRIPTION
fix for #2598: DITAVAL passthrough does not preserve attributes in HTML5 TOC.
Moved creating of property named "dita.input.valfile.url" from target "html5.init" to macrodef "html5.topics".

Signed-off-by: Vitaliy Danylyuk <vdanylyuk@intelliarts.com>